### PR TITLE
feat: add `Fresh` use to auto refresh expiration time

### DIFF
--- a/_example/refresh_maxage/main.go
+++ b/_example/refresh_maxage/main.go
@@ -1,0 +1,34 @@
+package main
+
+import (
+	"context"
+	"github.com/cloudwego/hertz/pkg/app"
+	"github.com/cloudwego/hertz/pkg/app/server"
+	"github.com/cloudwego/hertz/pkg/common/utils"
+	"github.com/hertz-contrib/sessions"
+	"github.com/hertz-contrib/sessions/cookie"
+	"sync"
+)
+
+var once sync.Once
+
+func main() {
+	h := server.New(server.WithHostPorts(":8000"))
+	store := cookie.NewStore([]byte("secret"))
+	store.Options(sessions.Options{MaxAge: 10})
+	h.Use(sessions.New("mysession", store))
+
+	h.GET("/login", func(ctx context.Context, c *app.RequestContext) {
+		s := sessions.Default(c)
+		once.Do(func() {
+			s.Set("key", "value")
+			s.Options(sessions.Options{MaxAge: -1})
+			s.Save()
+		})
+		i := s.Get("key")
+		c.JSON(200, utils.H{
+			"key": i,
+		})
+	}, sessions.Refresh(store))
+	h.Spin()
+}

--- a/cookie/cookie.go
+++ b/cookie/cookie.go
@@ -57,6 +57,11 @@ func (c *store) Options(opts sessions.Options) {
 	c.CookieStore.Options = opts.ToGorillaOptions()
 }
 
+// MaxAge returns the MaxAge in seconds of a session cookie.
+func (c *store) MaxAge() int {
+	return c.CookieStore.Options.MaxAge
+}
+
 func NewStore(keyPairs ...[]byte) Store {
 	return &store{gsessions.NewCookieStore(keyPairs...)}
 }

--- a/redis/redis.go
+++ b/redis/redis.go
@@ -55,6 +55,10 @@ type store struct {
 	*RediStore
 }
 
+func (s *store) MaxAge() int {
+	return s.RediStore.Options.MaxAge
+}
+
 func (s *store) Options(opts sessions.Options) {
 	s.RediStore.Options = opts.ToGorillaOptions()
 }


### PR DESCRIPTION
#### What type of PR is this?
feat
<!--
Add one of the following kinds:

build: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
ci: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
docs: Documentation only changes
feat: A new feature
optimize: A new optimization
fix: A bug fix
perf: A code change that improves performance
refactor: A code change that neither fixes a bug nor adds a feature
style: Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
test: Adding missing tests or correcting existing tests
chore: Changes to the build process or auxiliary tools and libraries such as documentation generation
-->

#### What this PR does / why we need it (English/Chinese):
en: add `Fresh` use to auto refresh expiration time
Example:
```go
var once sync.Once

func main() {
	h := server.New(server.WithHostPorts(":8000"))
	store := cookie.NewStore([]byte("secret"))
	store.Options(sessions.Options{MaxAge: 10})
	h.Use(sessions.New("mysession", store))

	h.GET("/login", func(ctx context.Context, c *app.RequestContext) {
		s := sessions.Default(c)
		once.Do(func() {
			s.Set("key", "value")
			s.Options(sessions.Options{MaxAge: -1})
			s.Save()
		})
		i := s.Get("key")
		c.JSON(200, utils.H{
			"key": i,
		})
	}, sessions.Refresh(store))
	h.Spin()
}

```
<!--
The description will be attached in Release Notes, 
so please describe it from user-oriented.
-->

#### Which issue(s) this PR fixes:
https://github.com/hertz-contrib/sessions/issues/7
<!--
*Automatically closes linked issue when PR is merged.
Eg: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
